### PR TITLE
fix modify/notify typo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,7 +78,7 @@
     group: root
     mode: 644
   register: sdc_systemd_updated
-  modify: "Restart {{ sdc_instance }}"
+  notify: "Restart {{ sdc_instance }}"
   when: ansible_service_mgr == "systemd"
 
 


### PR DESCRIPTION
Fixes a typo that was only a warning in Ansible ~2.4, but is an error in Ansible 2.7