### PR TITLE
ability to provide complete `sdc.properties` file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for ansible-datacollector
-sdc_version: 3.2.0.0
+sdc_version: 3.5.1
 sdc_release: "streamsets-datacollector-{{ sdc_version }}"
 sdc_tarball: "streamsets-datacollector-all-{{ sdc_version }}.tgz"
 sdc_release_url: "http://archives.streamsets.com.s3.amazonaws.com/datacollector/{{ sdc_version }}/tarball/{{ sdc_tarball }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ sdc_resources_dir: "{{ sdc_dist }}/resources"
 sdc_log_dir: "/var/log/{{ sdc_instance }}"
 sdc_conf_dir: "/etc/{{ sdc_instance }}"
 sdc_libexec_dir: "{{ sdc_dist }}/libexec"
+# add variable for sdc.properties template file,
+# to allow playbooks to specify the complete file
+sdc_properties: sdc.properties.j2
 # commonly tuned settings for sdc.properties.
 # full list of variables can be found by looking at templates/sdc.properties.j2
 http_port: 18630

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,9 @@
 
 - name: Deploy config template
   become_user: "{{ sdc_user }}"
-  template: dest="{{ sdc_conf_dir }}/sdc.properties" src=sdc.properties.j2
+  template: 
+    dest="{{ sdc_conf_dir }}/sdc.properties"
+    src="{{ sdc_properties }}"
   notify: "Restart {{ sdc_instance }}"
 
 - name: Deploy LDAP config

--- a/templates/sdc.properties.j2
+++ b/templates/sdc.properties.j2
@@ -391,7 +391,7 @@ stage.alias.streamsets-datacollector-cdh_5_10-lib,com_streamsets_pipeline_stage_
 # setup-mapr script will not work properly.
 # 
 #system.stagelibs.whitelist=
-system.stagelibs.blacklist=streamsets-datacollector-mapr_5_0-lib,streamsets-datacollector-mapr_5_1-lib,streamsets-datacollector-mapr_5_2-lib,streamsets-datacollector-mapr_6_0-lib,streamsets-datacollector-mapr_6_0-mep4-lib,streamsets-datacollector-mapr_spark_2_1_mep_3_0-lib
+system.stagelibs.blacklist=streamsets-datacollector-mapr_5_0-lib,streamsets-datacollector-mapr_5_1-lib,streamsets-datacollector-mapr_5_2-lib,streamsets-datacollector-mapr_6_0-lib,streamsets-datacollector-mapr_6_0-mep4-lib,streamsets-datacollector-mapr_6_0-mep5-lib,streamsets-datacollector-mapr_spark_2_1_mep_3_0-lib
 #
 #user.stagelibs.whitelist=
 #user.stagelibs.blacklist=


### PR DESCRIPTION
Looking at using sdc_version of 3.5.1, and it required additional changes to the `sdc.properties` file that was not currently supported.
Added the option to let the user provide a complete `sdc.properties` file, instead of always needing to adjust the available options.

But also updated the `system.stagelibs.blacklist` setting to support 3.5.1 by default.